### PR TITLE
Make soft_wrap configurable at instance level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Change the render prefix to correspond to the decimal units in progress
+- Add ability to use loggers that perform soft-wrapping
 
 ## [8.0.0] - 2020-10-03
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -7,3 +7,4 @@ The following people have contributed to the development of Rich:
 - [Oleksis Fraga](https://github.com/oleksis)
 - [Hedy Li](https://github.com/hedythedev)
 - [Will McGugan](https://github.com/willmcgugan)
+- [Sorin Sbarnea](https://github.com/ssbarnea)

--- a/examples/log-fluid.py
+++ b/examples/log-fluid.py
@@ -1,0 +1,40 @@
+"""
+Demonstrate differences between default logger handler and one that does
+implement soft-wrapping.
+"""
+import logging
+from rich.console import Console
+from rich.logging import RichHandler
+from rich._log_render import FluidLogRender
+
+handler_default = RichHandler(
+    console=Console(
+        force_terminal=True,
+        width=50,
+    )
+)
+handler_fluid = RichHandler(
+    console=Console(
+        force_terminal=True,
+        width=50,
+        soft_wrap=True,  # <-- This is required for fluid to work
+    )
+)
+# Changing internal as constructor does not allow custom renderer
+handler_fluid._log_render = FluidLogRender(
+    show_time=True, show_level=True, show_path=True
+)
+
+logging.basicConfig(
+    level="NOTSET",
+    format="%(message)s",
+    datefmt="[%X]",
+    handlers=[handler_default, handler_fluid],
+)
+log = logging.getLogger("rich")
+
+msg = (
+    "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod "
+    "tempor incididunt ut labore et dolore magna aliqua."
+)
+log.warning(msg)

--- a/rich/console.py
+++ b/rich/console.py
@@ -355,6 +355,7 @@ class Console:
         highlighter (HighlighterType, optional): Default highlighter.
         legacy_windows (bool, optional): Enable legacy Windows mode, or ``None`` to auto detect. Defaults to ``None``.
         safe_box (bool, optional): Restrict box options that don't render on legacy Windows.
+        soft_wrap (bool, optional): Default no_wrap value to use for print. Defaults to ``False``.
     """
 
     def __init__(
@@ -381,6 +382,7 @@ class Console:
         legacy_windows: bool = None,
         safe_box: bool = True,
         _environ: Dict[str, str] = None,
+        soft_wrap: bool = False,
     ):
         # Copy of os.environ allows us to replace it for testing
         self._environ = os.environ if _environ is None else _environ
@@ -428,6 +430,7 @@ class Console:
         )
         self._record_buffer: List[Segment] = []
         self._render_hooks: List[RenderHook] = []
+        self.soft_wrap = soft_wrap
 
     def __repr__(self) -> str:
         return f"<console width={self.width} {str(self._color_system)}>"
@@ -960,7 +963,7 @@ class Console:
         highlight: bool = None,
         width: int = None,
         crop: bool = True,
-        soft_wrap: bool = False,
+        soft_wrap: bool = None,
     ) -> None:
         """Print to the console.
 
@@ -977,11 +980,14 @@ class Console:
             highlight (Optional[bool], optional): Enable automatic highlighting, or ``None`` to use console default. Defaults to ``None``.
             width (Optional[int], optional): Width of output, or ``None`` to auto-detect. Defaults to ``None``.
             crop (Optional[bool], optional): Crop output to width of terminal. Defaults to True.
-            soft_wrap (bool, optional): Enable soft wrap mode which disables word wrapping and cropping. Defaults to False.
+            soft_wrap (bool, optional): Enable soft wrap mode which disables word wrapping and cropping. Defaults to None which uses instance preference.
         """
         if not objects:
             self.line()
             return
+
+        if soft_wrap is None:
+            soft_wrap = self.soft_wrap
 
         if soft_wrap:
             if no_wrap is None:


### PR DESCRIPTION
Allows user to define default soft_wrap behavior when creating
Console instances. This allows us to control wrapping without
having to modify each print() statements, something that may even
be impossible if called from within rich library itself.

## Type of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation / docstrings
- [ ] Tests
- [ ] Other

## Checklist

- [ ] I've run the latest [black](https://github.com/psf/black) with default args on new code.
- [ ] I've updated CHANGELOG.md and CONTRIBUTORS.md where appropriate.
- [ ] I've added tests for new code.
- [ ] I accept that @willmcgugan may be pedantic in the code review.

## Description

Please describe your changes here. If this fixes a bug, please link to the issue, if possible.
